### PR TITLE
v4l2: non-zero timestamp

### DIFF
--- a/v4l2-request-test.h
+++ b/v4l2-request-test.h
@@ -28,8 +28,8 @@
 #include <hevc-ctrls.h>
 
 #define ARRAY_SIZE(arr) (sizeof(arr) / sizeof((arr)[0]))
-#define TS_REF_INDEX(index) ((index) * 1000)
-#define INDEX_REF_TS(ts) ((ts) / 1000)
+#define TS_REF_INDEX(index) ((index + 1) * 1000)
+#define INDEX_REF_TS(ts) (((ts) / 1000) - 1)
 
 /*
  * Structures


### PR DESCRIPTION
The inital value of the timestamp of a buffer would be zero
and the type of the timestamp is unsigned.

So a valid timestamp would be non-zero.

Signed-off-by: Randy Li <randy.li@rock-chips.com>