### PR TITLE
introduce 'codec' structure

### DIFF
--- a/v4l2-request-test.c
+++ b/v4l2-request-test.c
@@ -37,6 +37,21 @@
 
 #include "v4l2-request-test.h"
 
+const struct codec codec[] = {
+	{
+		.name			= "MPEG-2",
+		.type			= CODEC_TYPE_MPEG2,
+	},
+	{
+		.name			= "H.264",
+		.type			= CODEC_TYPE_H264,
+	},
+	{
+		.name			= "H.265",
+		.type			= CODEC_TYPE_H265,
+	},
+};
+
 struct format_description formats[] = {
 	{
 		.description		= "NV12 YUV",

--- a/v4l2-request-test.c
+++ b/v4l2-request-test.c
@@ -39,16 +39,17 @@
 
 const struct codec codec[] = {
 	{
-		.name			= "MPEG-2",
-		.type			= CODEC_TYPE_MPEG2,
+		.name	= "MPEG-2",
+		.type	= CODEC_TYPE_MPEG2
 	},
 	{
-		.name			= "H.264",
-		.type			= CODEC_TYPE_H264,
+		.name	= "H.264",
+		.type	= CODEC_TYPE_H264
 	},
 	{
-		.name			= "H.265",
-		.type			= CODEC_TYPE_H265,
+		.name	= "H.265",
+		.type	= CODEC_TYPE_H265
+	}
 	},
 };
 

--- a/v4l2-request-test.c
+++ b/v4l2-request-test.c
@@ -117,20 +117,16 @@ static void print_summary(struct config *config, struct preset *preset)
 	printf(" Height: %d\n", preset->height);
 	printf(" Frames count: %d\n", preset->frames_count);
 
-	printf(" Format: ");
+	printf(" Codec Type:   ");
 
 	switch (preset->type) {
 	case CODEC_TYPE_MPEG2:
-		printf("MPEG2");
-		break;
 	case CODEC_TYPE_H264:
-		printf("H264");
-		break;
 	case CODEC_TYPE_H265:
-		printf("H265");
+		printf("%s", codec[preset->type].name);
 		break;
 	default:
-		printf("Invalid");
+		printf("Invalid codec type!");
 		break;
 	}
 

--- a/v4l2-request-test.h
+++ b/v4l2-request-test.h
@@ -124,6 +124,11 @@ struct preset {
 	unsigned int display_count;
 };
 
+extern const struct codec {
+	char *name;
+	enum codec_type type;
+} codec[];
+
 /* V4L2 */
 
 struct video_setup {


### PR DESCRIPTION
The 'presets' structures define a codec in the 'type' fiels as an enum value.
The enum definitions correspond with human readable names, which are accessible through this new 'codec' structure.

- const struct codec (.name, .type)
- use the 'name' field, when referencing the codecs in output messages