### PR TITLE
 introduce 'buffer_type' structure 

### DIFF
--- a/v4l2-request-test.c
+++ b/v4l2-request-test.c
@@ -37,6 +37,61 @@
 
 #include "v4l2-request-test.h"
 
+const struct buffer_type buffer_type[] = {
+	{
+	 	.name	= "Video Capture Buffer",
+	 	.type	= V4L2_BUF_TYPE_VIDEO_CAPTURE
+	},
+	{
+	 	.name	= "Video Output Buffer",
+	 	.type	= V4L2_BUF_TYPE_VIDEO_OUTPUT
+	},
+	{
+	 	.name	= "Video Overlay Buffer",
+	 	.type	= V4L2_BUF_TYPE_VIDEO_OVERLAY
+	},
+	{
+	 	.name	= "VBI Capture Buffer",
+	 	.type	= V4L2_BUF_TYPE_VBI_CAPTURE
+	},
+	{
+	 	.name	= "VBI Output Buffer",
+	 	.type	= V4L2_BUF_TYPE_VBI_OUTPUT
+	},
+	{
+	 	.name	= "Sliced VBI Capture Buffer",
+	 	.type	= V4L2_BUF_TYPE_SLICED_VBI_CAPTURE
+	},
+	{
+	 	.name	= "Sliced VBI Output Buffer",
+	 	.type	= V4L2_BUF_TYPE_SLICED_VBI_OUTPUT
+	},
+	{
+	 	.name	= "Video Output Overlay Buffer",
+	 	.type	= V4L2_BUF_TYPE_VIDEO_OUTPUT_OVERLAY
+	},
+	{
+	 	.name	= "Video Multi-Plane Capture Buffer",
+	 	.type	= V4L2_BUF_TYPE_VIDEO_CAPTURE_MPLANE
+	},
+	{
+	 	.name	= "Video Multi-Plane Output Buffer",
+	 	.type	= V4L2_BUF_TYPE_VIDEO_OUTPUT_MPLANE
+	},
+	{
+	 	.name	= "SDR Capture Buffer",
+	 	.type	= V4L2_BUF_TYPE_SDR_CAPTURE
+	},
+	{
+	 	.name	= "SDR Output Buffer",
+	 	.type	= V4L2_BUF_TYPE_SDR_OUTPUT
+	},
+	{
+	 	.name	= "Meta Capture Buffer",
+	 	.type	= V4L2_BUF_TYPE_META_CAPTURE
+	}
+};
+
 struct format_description formats[] = {
 	{
 		.description		= "NV12 YUV",

--- a/v4l2-request-test.h
+++ b/v4l2-request-test.h
@@ -124,6 +124,11 @@ struct preset {
 	unsigned int display_count;
 };
 
+extern const struct buffer_type {
+	char *name;
+	enum v4l2_buf_type type;
+} buffer_type[];
+
 /* V4L2 */
 
 struct video_setup {


### PR DESCRIPTION
When addressing buffers within V4L2, their types are defined in "enum v4l2_buf_type" in <videodev2.h>.
The enum definitions correspond with human readable names, which are accessible through this new 'buffer_type' structure.
- define a V4L2 buffer type structure (.name, .type)
- refer 'v4l2_buf_type' enum values to their lexical names