### PR TITLE
[v3] autodetect / driver scan

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,9 @@ DEPS = $(SOURCES:.c=.d)
 
 CFLAGS += -Wunused-variable -Iinclude
 CFLAGS += $(shell pkg-config --cflags libdrm)
+CFLAGS += $(shell pkg-config --cflags libudev)
 LDFLAGS = $(shell pkg-config --libs libdrm)
+LDFLAGS += $(shell pkg-config --libs libudev)
 
 # Produced files
 

--- a/data/bbb-h264-32/frames.h
+++ b/data/bbb-h264-32/frames.h
@@ -1,3 +1,5 @@
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wmissing-braces"
 	{
 		.index = 0,
 		.frame.h264 = {
@@ -9210,3 +9212,4 @@
 			},
 		},
 	},
+#pragma clang diagnostic pop

--- a/data/bbb-h264-all-i-32/frames.h
+++ b/data/bbb-h264-all-i-32/frames.h
@@ -1,3 +1,5 @@
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wmissing-braces"
 	{
 		.index = 0,
 		.frame.h264 = {
@@ -9129,3 +9131,4 @@
 			},
 		},
 	},
+#pragma clang diagnostic pop

--- a/data/bbb-h264-high-32/frames.h
+++ b/data/bbb-h264-high-32/frames.h
@@ -1,3 +1,5 @@
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wmissing-braces"
 	{
 		.index = 0,
 		.frame.h264 = {
@@ -9235,3 +9237,4 @@
 			},
 		},
 	},
+#pragma clang diagnostic pop

--- a/data/bbb-happy-mpeg2/frames.h
+++ b/data/bbb-happy-mpeg2/frames.h
@@ -1,3 +1,5 @@
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wmissing-braces"
 	{
 		.index = 0,
 		.frame.mpeg2.slice_params = {
@@ -1048,3 +1050,5 @@
 			.chroma_non_intra_quantiser_matrix = { 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, },
 		},
 	},
+#pragma clang diagnostic pop
+

--- a/data/bbb-mpeg2/frames.h
+++ b/data/bbb-mpeg2/frames.h
@@ -1,3 +1,5 @@
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wmissing-braces"
 	{
 		.index = 0,
 		.frame.mpeg2.slice_params = {
@@ -1048,3 +1050,4 @@
 			.chroma_non_intra_quantiser_matrix = { 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, },
 		},
 	},
+#pragma clang diagnostic pop

--- a/data/caminandes-fall-h265/frames.h
+++ b/data/caminandes-fall-h265/frames.h
@@ -1,3 +1,5 @@
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wmissing-braces"
 	{
 		.index = 0,
 		.frame.h265 = {
@@ -9780,3 +9782,4 @@
 			},
 		},
 	},
+#pragma clang diagnostic pop

--- a/data/caminandes-h265/frames.h
+++ b/data/caminandes-h265/frames.h
@@ -1,3 +1,5 @@
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wmissing-braces"
 	{
 		.index = 0,
 		.frame.h265 = {
@@ -9848,3 +9850,4 @@
 			},
 		},
 	},
+#pragma clang diagnostic pop

--- a/data/ed-mpeg2/frames.h
+++ b/data/ed-mpeg2/frames.h
@@ -1,3 +1,5 @@
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wmissing-braces"
 	{
 		.index = 0,
 		.frame.mpeg2.slice_params = {
@@ -1023,3 +1025,4 @@
 			.chroma_non_intra_quantiser_matrix = { 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, },
 		},
 	},
+#pragma clang diagnostic pop

--- a/decoder_test.c
+++ b/decoder_test.c
@@ -1,0 +1,126 @@
+/*
+ * Copyright (C) 2019 Ralf Zerres <ralf.zerres@networkx.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#define _GNU_SOURCE
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "decoder_test.h"
+
+int main(int argc, char *argv[])
+{
+	int id;
+	char *media_path;
+	char *video_path;
+	char *decoder_name;
+	struct v4l2_decoder *decoder = NULL;
+	struct v4l2_decoder *new_decoder = NULL;
+	struct vector *decoder_vector = NULL;
+
+	/* declare and initialize a new vector */
+	decoder_vector = calloc(1, sizeof(struct vector));
+	decoder_vector_init(decoder_vector);
+	printf("Vector initialized (num_entities: %d, capacity: %d)\n",
+	       decoder_vector->num_entities,
+	       decoder_vector->capacity);
+
+	/* initialize test entities */
+	decoder = calloc(1, sizeof(struct v4l2_decoder));
+
+	struct v4l2_decoder test0[] = {
+		{ .id		= 3,
+		  .name		= "cedrus-proc",
+		  .media_path	= "/dev/media3",
+		  .video_path	= "/dev/video5"
+		},
+	};
+
+	struct v4l2_decoder test1[] = {
+		{ .id		= 17,
+		  .name		= "video-dec-proc",
+		  .media_path	= "/dev/media2",
+		  .video_path	= "/dev/video4"
+		},
+	};
+
+	struct v4l2_decoder test2[] = {
+		{ .id		= 99,
+		  .name		= "test-proc",
+		  .media_path	= "/dev/media0",
+		  .video_path	= "/dev/video0"
+		},
+	};
+
+	/* Tests: create, remove, set, get vector entities */
+	printf("Test-1: Append 3 entities\n");
+	decoder_vector_append(decoder_vector, test0);
+	decoder_vector_append(decoder_vector, test1);
+	decoder_vector_append(decoder_vector, test2);
+	decoder_vector_print(decoder_vector);
+
+	printf("Test-2: Delete entity index 1\n");
+	decoder_vector_delete(decoder_vector, 1);
+	decoder_vector_print(decoder_vector);
+
+	printf("Test-3: Set entity 'test1 at index 2\n");
+	decoder_vector_set(decoder_vector, 2, test1);
+	decoder_vector_print(decoder_vector);
+
+	printf("Test-4: Append new entity\n");
+	id = 4;
+	media_path = "/dev/media4";
+	video_path = "/dev/video1";
+	decoder_name = "mydriver-proc";
+
+	decoder->id = id;
+	asprintf(&decoder->media_path, "%s", media_path);
+	asprintf(&decoder->video_path, "%s", video_path);
+	asprintf(&decoder->name, "%s", decoder_name);
+
+	decoder_vector_append(decoder_vector, decoder);
+	decoder_vector_print(decoder_vector);
+
+	printf("Test-5: Update entity at index 3\n");
+	video_path = "/dev/video2";
+	asprintf(&decoder->video_path, "%s", video_path);
+	decoder_vector_set(decoder_vector, 3, decoder);
+	decoder_vector_print(decoder_vector);
+
+	printf("Test-6: Append new entity\n");
+	//struct v4l2_decoder *new_decoder = malloc(sizeof(v4l2_decoder));
+	new_decoder = calloc(1, sizeof(struct v4l2_decoder));
+	id = 6;
+	media_path = "/dev/media1";
+	video_path = "/dev/video1";
+	decoder_name = "testdrv-proc";
+
+	new_decoder->id = id;
+	asprintf(&new_decoder->media_path, "%s", media_path);
+	asprintf(&new_decoder->video_path, "%s", video_path);
+	asprintf(&new_decoder->name, "%s", decoder_name);
+
+	decoder_vector_append(decoder_vector, new_decoder);
+	free ((void *)new_decoder);
+	decoder_vector_print(decoder_vector);
+
+	/* free underlying data array */
+	if (decoder)
+		free ((void *)decoder);
+
+	decoder_vector_free(decoder_vector);
+	printf("Vector freed\n");
+}

--- a/decoder_test.h
+++ b/decoder_test.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2019 Ralf Zerres <ralf.zerres@networkx.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef _V4L2_DECODERTEST_H_
+#define _V4L2_DECODERTEST_H_
+
+#include "decoder_vector.h"
+
+/*
+ * Functions
+ */
+
+/* Decoder Vector */
+
+//void decoder_vector_print(struct vector *decoder_vector);
+
+#endif

--- a/decoder_vector.c
+++ b/decoder_vector.c
@@ -1,0 +1,133 @@
+/*
+ * Copyright (C) 2019 Ralf Zerres <ralf.zerres@networkx.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#define _GNU_SOURCE
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "decoder_vector.h"
+
+//void decoder_vector_append(decoder_vector *decoder_vector, void *decoder) {
+void decoder_vector_append(struct vector *decoder_vector, struct v4l2_decoder *decoder)
+{
+	// make sure there's room to expand into
+	if (decoder_vector->capacity == decoder_vector->num_entities)
+		decoder_vector_extend(decoder_vector);
+
+	// append the decoder and increment element counter
+	decoder_vector->v4l2_decoders[decoder_vector->num_entities++] = decoder;
+}
+
+void decoder_vector_delete(struct vector *decoder_vector, int index)
+{
+    if (index < 0 || index >= decoder_vector->num_entities)
+	return;
+
+    decoder_vector->v4l2_decoders[index] = NULL;
+
+    for (int i = index; i < decoder_vector->capacity - 1; i++) {
+	decoder_vector->v4l2_decoders[i] = decoder_vector->v4l2_decoders[i + 1];
+	decoder_vector->v4l2_decoders[i + 1] = NULL;
+    }
+
+    decoder_vector->num_entities--;
+
+    decoder_vector_reduce(decoder_vector);
+}
+
+int decoder_vector_num_entities(struct vector *decoder_vector)
+{
+	return decoder_vector->num_entities;
+}
+
+static void decoder_vector_extend(struct vector *decoder_vector)
+{
+	if (decoder_vector->num_entities >= decoder_vector->capacity) {
+		/*
+		 * extend decoder_vector->capacity to hold another struct entity
+		 * and resize the allocated memory accordingly
+		 */
+		decoder_vector->capacity++;
+		decoder_vector->v4l2_decoders = realloc(decoder_vector->v4l2_decoders, sizeof(struct v4l2_decoder) * decoder_vector->capacity);
+	}
+}
+
+void decoder_vector_free(struct vector *decoder_vector)
+{
+	free(decoder_vector->v4l2_decoders);
+}
+
+void *decoder_vector_get(struct vector *decoder_vector, int index)
+{
+  if (index >= decoder_vector->num_entities || index < 0) {
+    printf("Index %d out of bounds for vector of %d entities\n", index, decoder_vector->num_entities);
+    return NULL;
+  }
+  return decoder_vector->v4l2_decoders[index];
+}
+
+void decoder_vector_init(struct vector *decoder_vector)
+{
+	// initialize num_entities and capacity
+	decoder_vector->num_entities = 0;
+	decoder_vector->capacity = 1;
+
+	// allocate memory for decoder_vector->data
+	decoder_vector->v4l2_decoders = calloc(decoder_vector->capacity, sizeof(struct v4l2_decoder));
+}
+
+void decoder_vector_print(struct vector *decoder_vector)
+{
+	printf("Vector: num_entities: %d, capacity: %d\n",
+	       decoder_vector->num_entities,
+	       decoder_vector->capacity);
+	for (int i = 0; i < decoder_vector_num_entities(decoder_vector); i++) {
+		struct v4l2_decoder *v = decoder_vector_get(decoder_vector, i);
+		printf("entity[%i]: %s (id: %i, media_path: %s, video_path: %s)\n",
+		       i,
+		       v->name,
+		       v->id,
+		       v->media_path,
+		       v->video_path);
+	}
+}
+
+static void decoder_vector_reduce(struct vector *decoder_vector)
+{
+	if (decoder_vector->num_entities > 0 &&
+	    decoder_vector->num_entities == decoder_vector->capacity -1) {
+		/*
+		 * reduce decoder_vector->capacity
+		 * and resize the allocated memory accordingly
+		 */
+		decoder_vector->capacity--;
+		decoder_vector->v4l2_decoders = realloc(decoder_vector->v4l2_decoders, sizeof(struct v4l2_decoder) * decoder_vector->capacity);
+	}
+}
+
+void decoder_vector_set(struct vector *decoder_vector, int index, void *decoder)
+{
+	/* zero fill the decoder_vector up to the desired index */
+	while (index >= decoder_vector->num_entities) {
+		decoder_vector_append(decoder_vector, decoder);
+	}
+
+	/* memcopy the given source structure at the desired index */
+	decoder_vector->v4l2_decoders[index] = decoder;
+	//memcpy (decoder_vector->v4l2_decoders[index], decoder, sizeof(decoder));
+}

--- a/decoder_vector.h
+++ b/decoder_vector.h
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2019 Ralf Zerres <ralf.zerres@networkx.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef _V4L2_VECTOR_H_
+#define _V4L2_VECTOR_H_
+
+//#include <linux/media.h>
+
+/*
+ * Structures
+ */
+
+/* media topology */
+
+struct v4l2_decoder {
+	int id;
+	char *name;
+	char *media_path;
+	char *video_path;
+};
+
+
+/*  Type:  v4l2_decoder vector */
+
+struct vector {
+	int num_entities;
+	int capacity;
+	void **v4l2_decoders;
+} decoder_vector;
+
+/*
+typedef struct {
+	int num_entities;
+	int capacity;
+	void **v4l2_decoders;
+} decoder_vector;
+*/
+
+/*
+ * Functions
+ */
+
+/* Decoder Vector */
+
+void decoder_vector_append(struct vector *decoder_vector, struct v4l2_decoder *value);
+void decoder_vector_delete(struct vector *decoder_vector, int index);
+static void decoder_vector_extend(struct vector *decoder_vector);
+void decoder_vector_free(struct vector *decoder_vector);
+void *decoder_vector_get(struct vector *decoder_vector, int index);
+void decoder_vector_init(struct vector *decoder_vector);
+int decoder_vector_num_entities(struct vector *decoder_vector);
+void decoder_vector_print(struct vector *decoder_vector);
+static void decoder_vector_reduce(struct vector *decoder_vector);
+void decoder_vector_set(struct vector *decoder_vector, int index, void *value);
+
+#endif

--- a/drm.c
+++ b/drm.c
@@ -457,8 +457,8 @@ static int select_crtc(int drm_fd, unsigned int encoder_id,
 	}
 
 	if (!crtc->mode_valid) {
-		fprintf(stderr, "Unable to get valid mode for CRTC %d\n",
-			crtc_id);
+		fprintf(stderr, "Unable to get valid mode for CRTC %p\n",
+			(void *) &crtc_id);
 		goto error;
 	}
 

--- a/meson.build
+++ b/meson.build
@@ -26,36 +26,21 @@ project('v4l2-request-test', 'c',
 
 cc = meson.get_compiler('c')
 
-#libdrm_headers = [
-#	'drm_fourcc.h'
-#]
-
-#libdrm_includes = [
-#	include_directories('include')
-#]
-
 libdrm_dependency = dependency('libdrm',
 	version: '>= 2.4.52',
 	method: 'pkg-config',
 	required: true)
-#	sources: [ libdrm_headers ],
-#	include_directories: libdrm_includes)
 
 libudev_dependency = dependency('libudev',
 	method: 'pkg-config',
 	required: true)
-
-#autoconf_data = configuration_data()
-
-#autoconf = configure_file(
-#	output: 'autoconfig.h',
-#	configuration: autoconf_data)
 
 sources = [
 	'drm.c',
 	'presets.c',
 	'decoder_vector.c',
 	'v4l2.c',
+	'v4l2-topology.c',
 	'v4l2-request-test.c'
 ]
 

--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,94 @@
+# Copyright (C) 2019 Bootlin
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sub license, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice (including the
+# next paragraph) shall be included in all copies or substantial portions
+# of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+# OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT.
+# IN NO EVENT SHALL PRECISION INSIGHT AND/OR ITS SUPPLIERS BE LIABLE FOR
+# ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+# TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+# SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+project('v4l2-request-test', 'c',
+	version: '1.0.0',
+	meson_version: '>= 0.43.0')
+
+cc = meson.get_compiler('c')
+
+#libdrm_headers = [
+#	'drm_fourcc.h'
+#]
+
+#libdrm_includes = [
+#	include_directories('include')
+#]
+
+libdrm_dependency = dependency('libdrm',
+	version: '>= 2.4.52',
+	method: 'pkg-config',
+	required: true)
+#	sources: [ libdrm_headers ],
+#	include_directories: libdrm_includes)
+
+libudev_dependency = dependency('libudev',
+	method: 'pkg-config',
+	required: true)
+
+#autoconf_data = configuration_data()
+
+#autoconf = configure_file(
+#	output: 'autoconfig.h',
+#	configuration: autoconf_data)
+
+sources = [
+	'drm.c',
+	'presets.c',
+	'decoder_vector.c',
+	'v4l2.c',
+	'v4l2-request-test.c'
+]
+
+headers = [
+	'decoder_vector.h',
+	'v4l2-topology.h',
+	'v4l2-request-test.h'
+]
+
+includes = [
+	include_directories('include')
+]
+
+cflags = [
+	'-Wall',
+	'-fvisibility=hidden'
+]
+
+deps = [
+	libdrm_dependency,
+	libudev_dependency
+]
+
+v4l2_request_test = executable('v4l2-request-test',
+	name_prefix: '',
+	install: true,
+	install_dir: '/usr/bin/',
+	c_args: cflags,
+	sources: [ sources, headers ],
+	include_directories: includes,
+	dependencies: deps)
+
+#tests = test('v4l2-request test',
+#	sources: v4l2_request_test)
+
+#v4l2_request_test_data = data('v4l2_request_test',)

--- a/meson.build
+++ b/meson.build
@@ -73,7 +73,26 @@ v4l2_request_test = executable('v4l2-request-test',
 	include_directories: includes,
 	dependencies: deps)
 
-#tests = test('v4l2-request test',
-#	sources: v4l2_request_test)
+decoder_sources = [
+	'decoder_vector.c',
+	'decoder_test.c'
+]
+
+decoder_headers = [
+	'decoder_vector.h',
+	'decoder_test.h'
+]
+
+decoder_vector = executable('decoder_vector',
+	name_prefix: '',
+	install: true,
+	install_dir: '/usr/bin/',
+	c_args: cflags,
+	sources: [ decoder_sources, decoder_headers ],
+	include_directories: includes,
+	dependencies: deps)
+
+test('decoder_vector test',
+	decoder_vector)
 
 #v4l2_request_test_data = data('v4l2_request_test',)

--- a/v4l2-request-test.c
+++ b/v4l2-request-test.c
@@ -335,15 +335,15 @@ static int load_data(const char *path, void **data, unsigned int *size)
 
 	fd = open(path, O_RDONLY);
 	if (fd < 0) {
-		fprintf(stderr, "Unable to open file path: %s\n",
-			strerror(errno));
+		fprintf(stderr, "Unable to open file path: %s (%d)\n",
+			strerror(errno), errno);
 		goto error;
 	}
 
 	rc = read(fd, buffer, length);
 	if (rc < 0) {
-		fprintf(stderr, "Unable to read file data: %s\n",
-			strerror(errno));
+		fprintf(stderr, "Unable to read file data: %s (%d)\n",
+			strerror(errno), errno);
 		goto error;
 	}
 
@@ -544,22 +544,22 @@ int main(int argc, char *argv[])
 
 	video_fd = open(config.video_path, O_RDWR | O_NONBLOCK, 0);
 	if (video_fd < 0) {
-		fprintf(stderr, "Unable to open video node: %s\n",
-			strerror(errno));
+		fprintf(stderr, "Unable to open video node: %s (%d)\n",
+			strerror(errno), errno);
 		goto error;
 	}
 
 	media_fd = open(config.media_path, O_RDWR | O_NONBLOCK, 0);
 	if (media_fd < 0) {
-		fprintf(stderr, "Unable to open media node: %s\n",
-			strerror(errno));
+		fprintf(stderr, "Unable to open media node: %s (%d)\n",
+			strerror(errno), errno);
 		goto error;
 	}
 
 	rc = ioctl(media_fd, MEDIA_IOC_DEVICE_INFO, &device_info);
 	if (rc < 0) {
-		fprintf(stderr, "Unable to get media device info: %s\n",
-			strerror(errno));
+		fprintf(stderr, "Unable to get media device info: %s (%d)\n",
+			strerror(errno), errno);
 		goto error;
 	}
 
@@ -567,8 +567,8 @@ int main(int argc, char *argv[])
 
 	drm_fd = drmOpen(config.drm_driver, config.drm_path);
 	if (drm_fd < 0) {
-		fprintf(stderr, "Unable to open DRM node: %s\n",
-			strerror(errno));
+		fprintf(stderr, "Unable to open DRM node: %s (%d)\n",
+			strerror(errno), errno);
 		goto error;
 	}
 

--- a/v4l2-request-test.c
+++ b/v4l2-request-test.c
@@ -110,22 +110,6 @@ const struct buffer_type buffer_type[] = {
 	}
 };
 
-const struct codec codec[] = {
-	{
-		.name	= "MPEG-2",
-		.type	= CODEC_TYPE_MPEG2
-	},
-	{
-		.name	= "H.264",
-		.type	= CODEC_TYPE_H264
-	},
-	{
-		.name	= "H.265",
-		.type	= CODEC_TYPE_H265
-	}
-	},
-};
-
 struct format_description formats[] = {
 	{
 		.description		= "NV12 YUV",

--- a/v4l2-request-test.c
+++ b/v4l2-request-test.c
@@ -29,7 +29,6 @@
 #include <sys/types.h>
 #include <time.h>
 #include <dirent.h>
-//#include <fcntl.h>
 #include <unistd.h>
 
 #include <drm_fourcc.h>
@@ -139,20 +138,22 @@ struct format_description formats[] = {
 
 static void print_help(void)
 {
-	printf("Usage: v4l2-request-test [OPTIONS] [SLICES PATH]\n\n"
-	       "Options:\n"
-	       " -v [video path]                path for the video node\n"
-	       " -m [media path]                path for the media node\n"
-	       " -d [DRM path]                  path for the DRM node\n"
-	       " -D [DRM driver]                DRM driver to use\n"
-	       " -s [slices filename format]    format for filenames in the slices path\n"
-	       " -f [fps]                       number of frames to display per second\n"
-	       " -P [video preset]              video preset to use\n"
-	       " -i                             enable interactive mode\n"
-	       " -l                             loop preset frames\n"
-	       " -q                             enable quiet mode\n"
-	       " -h                             help\n\n"
-	       "Video presets:\n");
+	printf("Usage: v4l2-request-test [OPTIONS]\n\n"
+		"Options:\n"
+		" -v  --video-device <dev>  Use device <dev> as the video device.\n"
+		"     --device\n"
+		" -m, --media-device <dev>  Use device <dev> as the media device.\n"
+		" -d, --drm-device <dev>    Use device <dev > as DRM device.\n"
+		" -D, --drm-driver <name>   Use given DRM driver.\n"
+		" -s, --slices-path <path>  Use <path> to find stored video slices.\n"
+		" -S, --slices-format <slices format>\n"
+		"                           Regex/format describing filenames stored in the slices path.\n"
+		" -f, --fps <fps>           Display given number of frames per seconds.\n"
+		" -P, --preset-name <name>  Use given preset-name for video decoding.\n"
+		" -i, --interactive         Enable interactive mode.\n"
+		" -l, --loop                Loop preset frames.\n"
+		" -q, --quiet               Enable quiet mode.\n"
+		" -h, --help                This help message.\n\n");
 
 	presets_usage();
 }
@@ -160,21 +161,21 @@ static void print_help(void)
 static void print_summary(struct config *config, struct preset *preset)
 {
 	printf("Config:\n");
-	printf(" Video path: %s\n", config->video_path);
-	printf(" Media path: %s\n", config->media_path);
-	printf(" DRM path: %s\n", config->drm_path);
-	printf(" DRM driver: %s\n", config->drm_driver);
-	printf(" Slices path: %s\n", config->slices_path);
-	printf(" Slices filename format: %s\n", config->slices_filename_format);
-	printf(" FPS: %d\n\n", config->fps);
+	printf(" Video device:  %s\n", config->video_path);
+	printf(" Media device:  %s\n", config->media_path);
+	printf(" DRM device:    %s\n", config->drm_path);
+	printf(" DRM driver:    %s\n", config->drm_driver);
+	printf(" Slices path:   %s\n", config->slices_path);
+	printf(" Slices format: %s\n", config->slices_filename_format);
+	printf(" FPS:           %d\n\n", config->fps);
 
 	printf("Preset:\n");
-	printf(" Name: %s\n", preset->name);
-	printf(" Description: %s\n", preset->description);
-	printf(" License: %s\n", preset->license);
-	printf(" Attribution: %s\n", preset->attribution);
-	printf(" Width: %d\n", preset->width);
-	printf(" Height: %d\n", preset->height);
+	printf(" Name:         %s\n", preset->name);
+	printf(" Description:  %s\n", preset->description);
+	printf(" License:      %s\n", preset->license);
+	printf(" Attribution:  %s\n", preset->attribution);
+	printf(" Width:        %d\n", preset->width);
+	printf(" Height:       %d\n", preset->height);
 	printf(" Frames count: %d\n", preset->frames_count);
 
 	printf(" Format: ");
@@ -498,7 +499,7 @@ int main(int argc, char *argv[])
 		};
 
 		opt = getopt_long(argc, argv, "v:m:d:D:s:S:f:P:ilqh",
-			     long_options, &option_index);
+				  long_options, &option_index);
 
 		if (opt == -1)
 			break;
@@ -521,6 +522,9 @@ int main(int argc, char *argv[])
 			config.drm_driver = strdup(optarg);
 			break;
 		case 's':
+			config.slices_path = strdup(optarg);
+			break;
+		case 'S':
 			free(config.slices_filename_format);
 			config.slices_filename_format = strdup(optarg);
 			break;
@@ -562,9 +566,7 @@ int main(int argc, char *argv[])
 
 	width = preset->width;
 	height = preset->height;
-	if (optind < argc)
-		config.slices_path = strdup(argv[optind]);
-	else
+	if (config.slices_path == NULL)
 		asprintf(&config.slices_path, "data/%s", config.preset_name);
 
 	print_summary(&config, preset);

--- a/v4l2-request-test.c
+++ b/v4l2-request-test.c
@@ -110,6 +110,22 @@ const struct buffer_type buffer_type[] = {
 	}
 };
 
+const struct codec codec[] = {
+	{
+		.name	= "MPEG-2",
+		.type	= CODEC_TYPE_MPEG2
+	},
+	{
+		.name	= "H.264",
+		.type	= CODEC_TYPE_H264
+	},
+	{
+		.name	= "H.265",
+		.type	= CODEC_TYPE_H265
+	}
+	},
+};
+
 struct format_description formats[] = {
 	{
 		.description		= "NV12 YUV",

--- a/v4l2-request-test.h
+++ b/v4l2-request-test.h
@@ -65,12 +65,6 @@ struct format_description {
 	unsigned int bpp;
 };
 
-struct media_entities {
-	char driver_name[16];
-	char media_path[128];
-	char video_path[128];
-};
-
 /* Presets */
 
 enum codec_type {
@@ -143,13 +137,6 @@ extern const struct buffer_type {
 } buffer_type[];
 
 /* V4L2 */
-
-enum media_gobj_type {
-	MEDIA_GRAPH_ENTITY,
-	MEDIA_GRAPH_PAD,
-	MEDIA_GRAPH_LINK,
-	MEDIA_GRAPH_INTF_DEVNODE,
-};
 
 struct video_setup {
 	unsigned int output_type;
@@ -247,14 +234,6 @@ int frame_gop_schedule(struct preset *preset, unsigned int index);
 
 /* V4L2 */
 
-static inline void *media_get_uptr(__u64 arg);
-static inline const char *media_gobj_type(uint32_t id);
-static inline const char *media_interface_type(uint32_t intf_type);
-static inline uint32_t media_localid(uint32_t id);
-//static char *media_objname(uint32_t id, char delimiter);
-static int media_scan_topology(struct config *config);
-static uint32_t media_type(uint32_t id);
-
 bool video_engine_capabilities_test(int video_fd,
 				    unsigned int capabilities_required);
 bool video_engine_format_test(int video_fd, bool mplane, unsigned int width,
@@ -286,7 +265,6 @@ int display_engine_show(int drm_fd, unsigned int index,
 
 /* udev */
 
-static char *udev_get_devpath(struct media_v2_intf_devnode *devnode);
 //static int udev_scan_subsystem(char *subsystem, struct config *config);
 
 #endif

--- a/v4l2-request-test.h
+++ b/v4l2-request-test.h
@@ -137,6 +137,11 @@ extern const struct codec {
 	enum codec_type type;
 } codec[];
 
+extern const struct buffer_type {
+	char *name;
+	enum v4l2_buf_type type;
+} buffer_type[];
+
 /* V4L2 */
 
 enum media_gobj_type {

--- a/v4l2-request-test.h
+++ b/v4l2-request-test.h
@@ -132,6 +132,11 @@ struct preset {
 	unsigned int display_count;
 };
 
+extern const struct codec {
+	char *name;
+	enum codec_type type;
+} codec[];
+
 /* V4L2 */
 
 enum media_gobj_type {

--- a/v4l2-request-test.h
+++ b/v4l2-request-test.h
@@ -31,6 +31,8 @@
 #define TS_REF_INDEX(index) ((index) * 1000)
 #define INDEX_REF_TS(ts) ((ts) / 1000)
 
+#define V4L2_DRIVER_NAME  "cedrus"
+
 /*
  * Structures
  */
@@ -61,6 +63,12 @@ struct format_description {
 	uint64_t drm_modifier;
 	unsigned int planes_count;
 	unsigned int bpp;
+};
+
+struct media_entities {
+	char driver_name[16];
+	char media_path[128];
+	char video_path[128];
 };
 
 /* Presets */
@@ -125,6 +133,13 @@ struct preset {
 };
 
 /* V4L2 */
+
+enum media_gobj_type {
+	MEDIA_GRAPH_ENTITY,
+	MEDIA_GRAPH_PAD,
+	MEDIA_GRAPH_LINK,
+	MEDIA_GRAPH_INTF_DEVNODE,
+};
 
 struct video_setup {
 	unsigned int output_type;
@@ -202,6 +217,9 @@ struct display_setup {
  * Functions
  */
 
+//static void print_help(void);
+//static void print_summary(struct config *config, struct preset *preset);
+
 /* Presets */
 
 void presets_usage(void);
@@ -218,6 +236,14 @@ int frame_gop_queue(unsigned int index);
 int frame_gop_schedule(struct preset *preset, unsigned int index);
 
 /* V4L2 */
+
+static inline void *media_get_uptr(__u64 arg);
+static inline const char *media_gobj_type(uint32_t id);
+static inline const char *media_interface_type(uint32_t intf_type);
+static inline uint32_t media_localid(uint32_t id);
+//static char *media_objname(uint32_t id, char delimiter);
+static int media_scan_topology(struct config *config);
+static uint32_t media_type(uint32_t id);
 
 bool video_engine_capabilities_test(int video_fd,
 				    unsigned int capabilities_required);
@@ -247,5 +273,10 @@ int display_engine_show(int drm_fd, unsigned int index,
 			struct video_buffer *video_buffers,
 			struct gem_buffer *buffers,
 			struct display_setup *setup);
+
+/* udev */
+
+static char *udev_get_devpath(struct media_v2_intf_devnode *devnode);
+//static int udev_scan_subsystem(char *subsystem, struct config *config);
 
 #endif

--- a/v4l2-topology.c
+++ b/v4l2-topology.c
@@ -1,0 +1,368 @@
+/*
+ * Copyright (C) 2019 Ralf Zerres <ralf.zerres@networkx.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * based on code:
+ * Media controller Next Generation test app
+ * Copyright (C) 2015 Mauro Carvalho Chehab <mchehab@osg.samsung.com>
+ */
+
+#define _GNU_SOURCE
+#include <errno.h>
+#include <fcntl.h>
+#include <libudev.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/ioctl.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#include <linux/videodev2.h>
+
+#include "v4l2-request-test.h"
+#include "v4l2-topology.h"
+#include "decoder_vector.h"
+
+static inline void *media_get_uptr(uint64_t arg)
+{
+	return (void *)(uintptr_t)arg;
+}
+
+enum media_gobj_type {
+	MEDIA_GRAPH_ENTITY,
+	MEDIA_GRAPH_PAD,
+	MEDIA_GRAPH_LINK,
+	MEDIA_GRAPH_INTF_DEVNODE,
+};
+
+static uint32_t media_type(uint32_t id)
+{
+	return id >> 24;
+}
+
+/*
+static inline const char *media_gobj_type(uint32_t id)
+{
+	switch (media_type(id)) {
+	case MEDIA_GRAPH_ENTITY:
+		return "entity";
+	case MEDIA_GRAPH_PAD:
+		return "pad";
+	case MEDIA_GRAPH_LINK:
+		return "link";
+	case MEDIA_GRAPH_INTF_DEVNODE:
+		return "devnode";
+	default:
+		return "unknown interface type";
+	}
+}
+*/
+
+static inline const char *media_interface_type(uint32_t intf_type)
+{
+	switch (intf_type) {
+	case MEDIA_INTF_T_DVB_FE:
+		return "frontend";
+	case MEDIA_INTF_T_DVB_DEMUX:
+		return "demux";
+	case MEDIA_INTF_T_DVB_DVR:
+		return "DVR";
+	case MEDIA_INTF_T_DVB_CA:
+		return  "CA";
+	case MEDIA_INTF_T_DVB_NET:
+		return "dvbnet";
+
+	case MEDIA_INTF_T_V4L_VIDEO:
+		return "video";
+	case MEDIA_INTF_T_V4L_VBI:
+		return "vbi";
+	case MEDIA_INTF_T_V4L_RADIO:
+		return "radio";
+	case MEDIA_INTF_T_V4L_SUBDEV:
+		return "v4l2-subdev";
+	case MEDIA_INTF_T_V4L_SWRADIO:
+		return "swradio";
+
+	case MEDIA_INTF_T_ALSA_PCM_CAPTURE:
+		return "pcm-capture";
+	case MEDIA_INTF_T_ALSA_PCM_PLAYBACK:
+		return "pcm-playback";
+	case MEDIA_INTF_T_ALSA_CONTROL:
+		return "alsa-control";
+	case MEDIA_INTF_T_ALSA_COMPRESS:
+		return "compress";
+	case MEDIA_INTF_T_ALSA_RAWMIDI:
+		return "rawmidi";
+	case MEDIA_INTF_T_ALSA_HWDEP:
+		return "hwdep";
+	case MEDIA_INTF_T_ALSA_SEQUENCER:
+		return "sequencer";
+	case MEDIA_INTF_T_ALSA_TIMER:
+		return "ALSA timer";
+	default:
+		return "unknown_intf";
+	}
+}
+
+static inline uint32_t media_localid(uint32_t id)
+{
+	return id & 0xffffff;
+}
+
+/*
+static char *media_objname(uint32_t id, char delimiter)
+{
+	char *name;
+	int ret;
+
+	ret = asprintf(&name, "%s%c%d",
+		       media_gobj_type(id),
+		       delimiter,
+		       media_localid(id));
+	if (ret < 0)
+		return NULL;
+
+	return name;
+}
+*/
+
+int media_scan_topology(struct v4l2_decoder *decoder)
+{
+	/* https://www.kernel.org/doc/html/v5.0/media/uapi/mediactl/media-ioc-g-topology.html */
+	struct media_v2_topology *topology = NULL;
+	struct media_device_info *device = NULL;
+	int i = 0;
+	int j = 0;
+	int media_fd = -1;
+	int rc = 0;
+	bool is_decoder = false;
+	__u64 topology_version;
+
+	fprintf(stderr, "Scan topology for media-device %s ...\n",
+		//decoder_vector->v4l2_decoders->media_path);
+		decoder->media_path);
+
+	//media_fd = open(decoder_vector->v4l2_decoders->media_path, O_RDWR | O_NONBLOCK, 0);
+	media_fd = open(decoder->media_path, O_RDWR | O_NONBLOCK, 0);
+	if (media_fd < 0) {
+		fprintf(stderr, "Unable to open media node: %s (%d)\n",
+			strerror(errno), errno);
+		return rc;
+	}
+
+	device = calloc(1, sizeof(struct media_device_info));
+	rc = ioctl(media_fd, MEDIA_IOC_DEVICE_INFO, device);
+	if (rc < 0) {
+		fprintf(stderr, " error: media device info can't be initialized!\n");
+		return rc;
+	}
+
+	printf(" driver: %s (model: %s, bus: %s, api-version: %d, driver-version: %d)\n",
+	       device->driver,
+	       device->model,
+	       device->bus_info,
+	       device->media_version,
+	       device->driver_version);
+
+	/*
+	 * Initialize topology structure
+	 * a) zero the topology structure
+	 * b) ioctl to get amount of elements
+	 */
+	topology = calloc(1, sizeof(struct media_v2_topology));
+
+	rc = ioctl(media_fd, MEDIA_IOC_G_TOPOLOGY, topology);
+	if (rc < 0) {
+		fprintf(stderr, " error: topology can't be initialized!\n");
+		return rc;
+	}
+
+	topology_version = topology->topology_version;
+	printf(" topology: version %lld (entries: %d, interfaces: %d, pads: %d, links: %d\n",
+	       topology->topology_version,
+	       topology->num_entities,
+	       topology->num_interfaces,
+	       topology->num_pads,
+	       topology->num_links);
+
+	/*
+	 * Update topology structures
+	 * a) set pointers to media structures we are interested in (mem-allocation)
+	 * b) ioctl to update structure element values
+	 */
+	do {
+		if(topology->num_entities > 0)
+			topology->ptr_entities = (__u64)calloc(topology->num_entities,
+							      sizeof(struct media_v2_entity));
+		if (topology->num_entities && !topology->ptr_entities)
+			goto error;
+
+		if(topology->num_interfaces > 0)
+			topology->ptr_interfaces = (__u64)calloc(topology->num_interfaces,
+								sizeof(struct media_v2_interface));
+		if (topology->num_interfaces && !topology->ptr_interfaces)
+			goto error;
+
+		/* not interested in other structures */
+		topology->ptr_pads = 0;
+		topology->ptr_links = 0;
+
+		/* 2nd call: get updated topology structure elements */
+		rc = ioctl(media_fd, MEDIA_IOC_G_TOPOLOGY, topology);
+		if (rc < 0) {
+			if (topology->topology_version != topology_version) {
+				fprintf(stderr, " Topology changed from version %lld to %lld. Trying again.\n",
+					topology_version,
+					topology->topology_version);
+				free((void *)topology->ptr_entities);
+				free((void *)topology->ptr_interfaces);
+				topology_version = topology->topology_version;
+				continue;
+			}
+			fprintf(stderr, " Topology %lld update error!\n",
+				topology_version);
+			goto error;
+		}
+	} while (rc < 0);
+
+	/*
+	 * Pick up all available video decoder entities, that support
+	 * function 'MEDIA_ENT_F_PROC_VIDEO_DECODER':
+	 * -> decompresing a compressd video stream into uncompressed video frames
+	 * -> has one sink
+	 * -> at least one source
+	 */
+	struct media_v2_entity *entities = media_get_uptr(topology->ptr_entities);
+	for(i=0; i < topology->num_entities; i++) {
+		struct media_v2_entity *entity = &entities[i];
+		if (entity->function == MEDIA_ENT_F_PROC_VIDEO_DECODER) {
+			is_decoder = true;
+			rc = 1;
+			decoder->id = entity->id;
+			asprintf(&decoder->name, "%s", entity->name);
+		}
+		/*
+		   else
+			fprintf(stderr, " entity: %s (id: %d) can't decode\n",
+				entity->name,
+				entity->id);
+		*/
+	}
+
+	/*
+	 * Pick interface
+	 * -> type: 'MEDIA_INTF_T_V4L_VIDEO'
+	 * -> device: typically /dev/video?
+	 */
+	if (is_decoder) {
+		struct media_v2_interface *interfaces = media_get_uptr(topology->ptr_interfaces);
+		for (j=0; j < topology->num_interfaces; j++) {
+			struct media_v2_interface *interface = &interfaces[j];
+			struct media_v2_intf_devnode *devnode = &interface->devnode;
+			//char *obj;
+			char *video_path;
+
+			if (interface->intf_type == MEDIA_INTF_T_V4L_VIDEO) {
+				/* TODO: cedurs proc doesn't assing devnode->minor
+				   fprintf(stderr, " devnode: major->%d, minor->%d\n",
+				   devnode->major,
+				   devnode->minor);
+				*/
+				video_path = udev_get_devpath(devnode);
+				asprintf(&decoder->video_path, "%s", video_path);
+
+				fprintf(stderr, " interface: type %s, device %s\n",
+					media_interface_type(interface->intf_type),
+					video_path);
+
+				/*
+				  obj = media_objname(interface->id, '#');
+				  fprintf(stderr, "%s: interface-type %s, device %s\n",
+				  obj,
+				  media_interface_type(interface->intf_type),
+				  video_path);
+				*/
+			}
+		}
+	}
+
+	goto complete;
+	//printf("Total number of suitable Video-Decoders: %u\n", index);
+
+error:
+	rc = -1;
+
+complete:
+	if (topology->ptr_entities) {
+		free((void *)topology->ptr_entities);
+		topology->ptr_entities = 0;
+	}
+	if (topology->ptr_interfaces) {
+		free((void *)topology->ptr_interfaces);
+		topology->ptr_interfaces = 0;
+		}
+	/*
+	if (topology->ptr_pads)
+		free((void *)topology->ptr_pads);
+	if (topology->ptr_links)
+		free((void *)topology->ptr_links);
+	*/
+
+	//topology->ptr_pads = 0;
+	//topology->ptr_links = 0;
+
+	if (device)
+		free((void *)device);
+
+	if (media_fd >= 0)
+		close(media_fd);
+
+	return rc;
+}
+
+static char *udev_get_devpath(struct media_v2_intf_devnode *devnode)
+{
+	struct udev *udev;
+	struct udev_device *device;
+	dev_t devnum;
+	const char *ptr_devname;
+	char *devname = NULL;
+	int rs;
+
+	udev = udev_new();
+	if (!udev) {
+		fprintf(stderr, " Can’t create udev object\n");
+		return NULL;
+	}
+
+	devnum = makedev(devnode->major, devnode->minor);
+	device = udev_device_new_from_devnum(udev, 'c', devnum);
+	if (device) {
+		ptr_devname = udev_device_get_devnode(device);
+		if (ptr_devname) {
+			rs = asprintf(&devname, "%s", ptr_devname);
+			if (rs < 0)
+				return NULL;
+		}
+	}
+
+	udev_device_unref(device);
+
+	return devname;
+}

--- a/v4l2-topology.h
+++ b/v4l2-topology.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2019 Ralf Zerres <ralf.zerres@networkx.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef _V4L2_TOPOLOGY_H_
+#define _V4L2_TOPOLOGY_H_
+
+#include <libudev.h>
+#include <linux/media.h>
+
+#include "decoder_vector.h"
+
+/*
+ * Functions
+ */
+
+/* V4L2 */
+
+static inline void *media_get_uptr(uint64_t arg);
+//static inline const char *media_gobj_type(uint32_t id);
+static inline const char *media_interface_type(uint32_t intf_type);
+static inline uint32_t media_localid(uint32_t id);
+//static char *media_objname(uint32_t id, char delimiter);
+int media_scan_topology(struct v4l2_decoder *decoder);
+//static uint32_t media_type(uint32_t id);
+
+/* udev */
+
+static char *udev_get_devpath(struct media_v2_intf_devnode *devnode);
+
+#endif

--- a/v4l2.c
+++ b/v4l2.c
@@ -140,8 +140,8 @@ static int try_format(int video_fd, unsigned int type, unsigned int width,
 
 	rc = ioctl(video_fd, VIDIOC_TRY_FMT, &format);
 	if (rc < 0) {
-		fprintf(stderr, "Unable to try format for type %d: %s\n", type,
-			strerror(errno));
+		fprintf(stderr, "Unable to try format for type %d: %s (%d)\n",
+			type, strerror(errno), errno);
 		return -1;
 	}
 
@@ -158,8 +158,8 @@ static int set_format(int video_fd, unsigned int type, unsigned int width,
 
 	rc = ioctl(video_fd, VIDIOC_S_FMT, &format);
 	if (rc < 0) {
-		fprintf(stderr, "Unable to set format for type %d: %s\n", type,
-			strerror(errno));
+		fprintf(stderr, "Unable to set format for type %d: %s (%d)\n",
+			type, strerror(errno), errno);
 		return -1;
 	}
 
@@ -180,8 +180,8 @@ static int get_format(int video_fd, unsigned int type, unsigned int *width,
 
 	rc = ioctl(video_fd, VIDIOC_G_FMT, &format);
 	if (rc < 0) {
-		fprintf(stderr, "Unable to get format for type %d: %s\n", type,
-			strerror(errno));
+		fprintf(stderr, "Unable to get format for type %d: %s (%d)\n",
+			type, strerror(errno), errno);
 		return -1;
 	}
 
@@ -242,15 +242,15 @@ static int create_buffers(int video_fd, unsigned int type,
 
 	rc = ioctl(video_fd, VIDIOC_G_FMT, &buffers.format);
 	if (rc < 0) {
-		fprintf(stderr, "Unable to get format for type %d: %s\n", type,
-			strerror(errno));
+		fprintf(stderr, "Unable to get format for type %d: %s (%d)\n", type,
+			strerror(errno), errno);
 		return -1;
 	}
 
 	rc = ioctl(video_fd, VIDIOC_CREATE_BUFS, &buffers);
 	if (rc < 0) {
-		fprintf(stderr, "Unable to create buffer for type %d: %s\n",
-			type, strerror(errno));
+		fprintf(stderr, "Unable to create buffer for type %d: %s (%d)\n",
+			type, strerror(errno), errno);
 		return -1;
 	}
 
@@ -280,8 +280,8 @@ static int query_buffer(int video_fd, unsigned int type, unsigned int index,
 
 	rc = ioctl(video_fd, VIDIOC_QUERYBUF, &buffer);
 	if (rc < 0) {
-		fprintf(stderr, "Unable to query buffer: %s\n",
-			strerror(errno));
+		fprintf(stderr, "Unable to query buffer: %s (%d)\n",
+			strerror(errno), errno);
 		return -1;
 	}
 
@@ -317,8 +317,8 @@ static int request_buffers(int video_fd, unsigned int type,
 
 	rc = ioctl(video_fd, VIDIOC_REQBUFS, &buffers);
 	if (rc < 0) {
-		fprintf(stderr, "Unable to request buffers: %s\n",
-			strerror(errno));
+		fprintf(stderr, "Unable to request buffers: %s (%d)\n",
+			strerror(errno), errno);
 		return -1;
 	}
 
@@ -359,8 +359,8 @@ static int queue_buffer(int video_fd, int request_fd, unsigned int type,
 
 	rc = ioctl(video_fd, VIDIOC_QBUF, &buffer);
 	if (rc < 0) {
-		fprintf(stderr, "Unable to queue buffer: %s\n",
-			strerror(errno));
+		fprintf(stderr, "Unable to queue buffer: %s (%d)\n",
+			strerror(errno), errno);
 		return -1;
 	}
 
@@ -391,8 +391,8 @@ static int dequeue_buffer(int video_fd, int request_fd, unsigned int type,
 
 	rc = ioctl(video_fd, VIDIOC_DQBUF, &buffer);
 	if (rc < 0) {
-		fprintf(stderr, "Unable to dequeue buffer: %s\n",
-			strerror(errno));
+		fprintf(stderr, "Unable to dequeue buffer: %s (%d)\n",
+			strerror(errno), errno);
 		return -1;
 	}
 
@@ -419,8 +419,8 @@ static int export_buffer(int video_fd, unsigned int type, unsigned int index,
 
 		rc = ioctl(video_fd, VIDIOC_EXPBUF, &exportbuffer);
 		if (rc < 0) {
-			fprintf(stderr, "Unable to export buffer: %s\n",
-				strerror(errno));
+			fprintf(stderr, "Unable to export buffer: %s (%d)\n",
+				strerror(errno), errno);
 			return -1;
 		}
 
@@ -454,7 +454,8 @@ static int set_control(int video_fd, int request_fd, unsigned int id,
 
 	rc = ioctl(video_fd, VIDIOC_S_EXT_CTRLS, &controls);
 	if (rc < 0) {
-		fprintf(stderr, "Unable to set control: %s\n", strerror(errno));
+		fprintf(stderr, "Unable to set control: %s (%d)\n",
+			strerror(errno), errno);
 		return -1;
 	}
 
@@ -469,8 +470,8 @@ static int set_stream(int video_fd, unsigned int type, bool enable)
 	rc = ioctl(video_fd, enable ? VIDIOC_STREAMON : VIDIOC_STREAMOFF,
 		   &buf_type);
 	if (rc < 0) {
-		fprintf(stderr, "Unable to %sable stream: %s\n",
-			enable ? "en" : "dis", strerror(errno));
+		fprintf(stderr, "Unable to %sable stream: %s (%d)\n",
+			enable ? "en" : "dis", strerror(errno), errno);
 		return -1;
 	}
 
@@ -571,8 +572,8 @@ bool video_engine_capabilities_test(int video_fd,
 
 	rc = query_capabilities(video_fd, &capabilities);
 	if (rc < 0) {
-		fprintf(stderr, "Unable to query video capabilities: %s\n",
-			strerror(errno));
+		fprintf(stderr, "Unable to query video capabilities: %s (%d)\n",
+			strerror(errno), errno);
 		return false;
 	}
 
@@ -790,8 +791,8 @@ int video_engine_start(int video_fd, int media_fd, unsigned int width,
 		rc = ioctl(media_fd, MEDIA_IOC_REQUEST_ALLOC, &request_fd);
 		if (rc < 0) {
 			fprintf(stderr,
-				"Unable to allocate media request: %s\n",
-				strerror(errno));
+				"Unable to allocate media request: %s (%d)\n",
+				strerror(errno), errno);
 			goto error;
 		}
 
@@ -905,8 +906,8 @@ int video_engine_decode(int video_fd, unsigned int index, union controls *frame,
 
 	rc = ioctl(request_fd, MEDIA_REQUEST_IOC_QUEUE, NULL);
 	if (rc < 0) {
-		fprintf(stderr, "Unable to queue media request: %s\n",
-			strerror(errno));
+		fprintf(stderr, "Unable to queue media request: %s (%d)\n",
+			strerror(errno), errno);
 		return -1;
 	}
 
@@ -918,8 +919,8 @@ int video_engine_decode(int video_fd, unsigned int index, union controls *frame,
 		fprintf(stderr, "Timeout when waiting for media request\n");
 		return -1;
 	} else if (rc < 0) {
-		fprintf(stderr, "Unable to select media request: %s\n",
-			strerror(errno));
+		fprintf(stderr, "Unable to select media request: %s (%d)\n",
+			strerror(errno), errno);
 		return -1;
 	}
 
@@ -945,8 +946,8 @@ int video_engine_decode(int video_fd, unsigned int index, union controls *frame,
 
 	rc = ioctl(request_fd, MEDIA_REQUEST_IOC_REINIT, NULL);
 	if (rc < 0) {
-		fprintf(stderr, "Unable to reinit media request: %s\n",
-			strerror(errno));
+		fprintf(stderr, "Unable to reinit media request: %s (%d)\n",
+			strerror(errno), errno);
 		return -1;
 	}
 


### PR DESCRIPTION
### autodetect / media-driver scan
[v3] autoprobing devices
in default mode user needs to provide working video- and media-device names.
This patch will introduce needed infrastructure to autoscan suitable devices.

- introduce libudev support: scan the class 'media' for available v4l2 devices
- introduce topologie scan:  parse entities and interfaces that  do provide 
  video-decoding functionality
- introduce decoder vector:  store v4l2 entities from capable decoder drivers
- preset config values for 'video_path' and 'media_path'
  using the first named 'cedrus'
- given commandline config options have precedence
- update meson build:  
  - project: v4l2-request-test
  - test: decoder_vector
  - dependencies: libs, cflags
- introduce const struct codec (.name, .type)
  use a descriptive name when referencing codecs by enum type
- clang: overcome compiler warnings 'missing braces'
  use pragma defines push/pop just around the frames.h content
- update: rebase parsing for 'long options'

[v2] autoprobing media devices via libudev 
- if target system did register multiple v4l2 devices,
  the user needs to select a cedrus aware video and media path.
  This patch will use libudev, to scan the classes 'video4linux'
  and 'media'.
- will preset the config values for 'video_path' and 'media_path'
  using the first match corresponding to driver named 'cedrus'.
- respect user selected config options, which will have precedence
- update build systems to include needed symbols (libs, cflags)
- extend output on error messages
  beside the literal string, also output the error int number

[v1] autoscan for video_path 
- scan via sys-path (using dirent.h)